### PR TITLE
Use flex and internal scrolling for dashboard

### DIFF
--- a/ui/dashboard.css
+++ b/ui/dashboard.css
@@ -19,10 +19,10 @@
 *{box-sizing:border-box}
 html,body{
   height:100%;
-  margin: 0;
   overflow: hidden;
 }
 body{
+  margin: 0;
   font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
   color: var(--text);
   background:
@@ -32,7 +32,7 @@ body{
     var(--bg);
 }
 
-.app{display:grid;grid-template-columns:290px 1fr;min-height:100vh;height: 100%;}
+.app{display:grid;grid-template-columns:290px 1fr;height: 100%;}
 
 /* Sidebar */
 .sidebar{
@@ -117,7 +117,6 @@ body{
   height: 100%;
   display: flex;
   flex-flow: column;
-  max-height: 100%;
   min-height: 0;
 }
 
@@ -283,33 +282,32 @@ body{
   flex-flow: column;
   flex: 1;
   min-height: 0;
-
 }
+
 
 .tableWrap{
   border:1px solid var(--border);
   border-radius: 16px;
   background: rgba(255,255,255,0.03);
   /* Limit height so growth scrolls inside this box instead of the page */
-  max-height: calc(100vh - 220px);
-  -webkit-overflow-scrolling: touch;
+  /* Use flexbox to make the table area fill the available space and scroll internally */
+  flex: 1;
+  overflow: hidden;
   /* nicer scroll for Firefox */
-  scrollbar-width: thin;
-  scrollbar-color: rgba(255,255,255,0.4) transparent;
   display: flex;
   flex-flow: column;
   min-height: 0;
 }
 /* WebKit scrollbar styling */
-.tableWrap::-webkit-scrollbar{width:10px;height:10px}
-.tableWrap::-webkit-scrollbar-thumb{
-  background: rgba(255,255,255,0.06);
+.categoryList::-webkit-scrollbar{width:10px;height:10px}
+.categoryList::-webkit-scrollbar-thumb{
+  background: rgba(255,255,255,0.4);
   border-radius:999px;
   border:2px solid transparent;
   background-clip: padding-box;
 }
-.tableWrap::-webkit-scrollbar-thumb:hover{background: rgba(255,255,255,0.12)}
-.tableWrap::-webkit-scrollbar-track{background: transparent}
+.categoryList::-webkit-scrollbar-thumb:hover{background: rgba(255,255,255,0.12)}
+.categoryList::-webkit-scrollbar-track{background: transparent}
 .table{width:100%;border-collapse:collapse;font-size:13px}
 .table th,.table td{padding:10px 10px;border-bottom:1px solid rgba(234,240,255,0.10);vertical-align:top}
 .table th{position:sticky;top:0;background: rgba(11,15,23,0.6);backdrop-filter: blur(8px);text-align:left;font-size:12px;color: rgba(234,240,255,0.85);z-index:2}
@@ -442,6 +440,8 @@ svg .axis line, svg .axis path{stroke: rgba(234,240,255,0.18)}
   flex-direction:column;
   gap:10px;
   overflow: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255,255,255,0.4) transparent;
 }
 .categoryList li{
   display:flex;

--- a/ui/dashboard.css
+++ b/ui/dashboard.css
@@ -17,9 +17,12 @@
 }
 
 *{box-sizing:border-box}
-html,body{height:100%}
+html,body{
+  height:100%;
+  margin: 0;
+  overflow: hidden;
+}
 body{
-  margin:0;
   font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
   color: var(--text);
   background:
@@ -29,7 +32,7 @@ body{
     var(--bg);
 }
 
-.app{display:grid;grid-template-columns:290px 1fr;min-height:100vh}
+.app{display:grid;grid-template-columns:290px 1fr;min-height:100vh;height: 100%;}
 
 /* Sidebar */
 .sidebar{
@@ -109,7 +112,14 @@ body{
 .visually-hidden{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 
 /* Main */
-.main{padding:18px 18px 22px}
+.main{
+  padding:18px 18px 22px;
+  height: 100%;
+  display: flex;
+  flex-flow: column;
+  max-height: 100%;
+  min-height: 0;
+}
 
 .topbar{
   position:sticky;
@@ -234,6 +244,10 @@ body{
   border-radius: var(--radius);
   padding:12px;
   box-shadow: var(--shadow);
+  display: flex;
+  flex-flow: column;
+  flex: 1;
+  min-height: 0;
 }
 .cardTitle{font-weight:900;font-size:13px;margin-bottom:10px;letter-spacing:0.2px}
 
@@ -264,7 +278,38 @@ body{
 
 .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
 
-.tableWrap{overflow:auto;border:1px solid var(--border);border-radius: 16px;background: rgba(255,255,255,0.03)}
+.view{
+  display: flex;
+  flex-flow: column;
+  flex: 1;
+  min-height: 0;
+
+}
+
+.tableWrap{
+  border:1px solid var(--border);
+  border-radius: 16px;
+  background: rgba(255,255,255,0.03);
+  /* Limit height so growth scrolls inside this box instead of the page */
+  max-height: calc(100vh - 220px);
+  -webkit-overflow-scrolling: touch;
+  /* nicer scroll for Firefox */
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255,255,255,0.4) transparent;
+  display: flex;
+  flex-flow: column;
+  min-height: 0;
+}
+/* WebKit scrollbar styling */
+.tableWrap::-webkit-scrollbar{width:10px;height:10px}
+.tableWrap::-webkit-scrollbar-thumb{
+  background: rgba(255,255,255,0.06);
+  border-radius:999px;
+  border:2px solid transparent;
+  background-clip: padding-box;
+}
+.tableWrap::-webkit-scrollbar-thumb:hover{background: rgba(255,255,255,0.12)}
+.tableWrap::-webkit-scrollbar-track{background: transparent}
 .table{width:100%;border-collapse:collapse;font-size:13px}
 .table th,.table td{padding:10px 10px;border-bottom:1px solid rgba(234,240,255,0.10);vertical-align:top}
 .table th{position:sticky;top:0;background: rgba(11,15,23,0.6);backdrop-filter: blur(8px);text-align:left;font-size:12px;color: rgba(234,240,255,0.85);z-index:2}
@@ -392,11 +437,11 @@ svg .axis line, svg .axis path{stroke: rgba(234,240,255,0.18)}
 /* Categories list (adaptação visual para o dashboard) */
 .categoryList{
   list-style:none;
-  padding:0;
-  margin:10px 0 0 0;
+  padding:10px;
   display:flex;
   flex-direction:column;
   gap:10px;
+  overflow: auto;
 }
 .categoryList li{
   display:flex;


### PR DESCRIPTION
[Resolve o problema do scroll na página toda, fazendo scroll somente na área específica da lista de categorias] Rework dashboard CSS to use flexbox and confine scrolling to inner panels. Set html/body to full height and hide page-level overflow; make .app and .main stretch to fill height and use column flex flow; convert cards and .view to flex containers with min-height:0. Change .tableWrap to a scrollable flex container with max-height and add scrollbar styling (WebKit + Firefox). Adjust categoryList padding/overflow so lists scroll inside their container instead of the whole page.

Relacionado à issue: #