### PR TITLE
Add flex-fill/u-scroll utilities and apply to sidebar

### DIFF
--- a/ui/dashboard.css
+++ b/ui/dashboard.css
@@ -470,7 +470,7 @@ svg .axis line, svg .axis path{stroke: rgba(234,240,255,0.18)}
   Ela força o elemento a ocupar todo o espaço restante e impede 
   que ele cresça além da tela (o que quebraria o scroll interno).
 */
-.flex-fill-col {
+.u-flex-fill-col {
   display: flex;
   flex-flow: column;
   flex: 1;
@@ -482,7 +482,7 @@ svg .axis line, svg .axis path{stroke: rgba(234,240,255,0.18)}
   Use esta classe no elemento que deve ter a barra de rolagem (a <ul>, <table> ou div wrapper).
 */
 .u-scroll-y {
-  overflow-y: overlay;        /* Habilita scroll vertical */
+  overflow-y: auto;           /* Habilita scroll vertical (compatível cross-browser) */
   overflow-x: hidden;      /* Evita scroll horizontal acidental em listas */
   flex: 1;                 /* Ocupa o espaço disponível dentro do container flex pai */  
   min-height: 0;           /* Permite que o conteúdo encolha e o scroll funcione corretamente */ 

--- a/ui/dashboard.html
+++ b/ui/dashboard.html
@@ -19,7 +19,7 @@
   <body>
     <div class="app">
       
-      <aside class="sidebar flex-fill-col">
+      <aside class="sidebar u-flex-fill-col">
         <div class="brand">
           <div class="logo">
             <picture>
@@ -33,7 +33,7 @@
           </div>
         </div>
 
-        <nav class="nav flex-fill-col u-scroll-y">
+        <nav class="nav u-flex-fill-col u-scroll-y">
           <button class="navBtn active" data-view="overview">📌 Visão geral</button>
           <button class="navBtn" data-view="categories">🎨 Categorias</button>
           <button class="navBtn" data-view="papers">📚 Artigos</button>
@@ -60,7 +60,7 @@
         </header>
 
         <!-- OVERVIEW -->
-        <section class="view flex-fill-col" id="view_overview">
+        <section class="view u-flex-fill-col" id="view_overview">
           <div class="kpiGrid">
             <div class="kpi"><div class="kpiLabel">Total</div><div class="kpiVal" id="kpi_total">0</div></div>
             <div class="kpi"><div class="kpiLabel">Incluídos</div><div class="kpiVal" id="kpi_included">0</div></div>
@@ -99,7 +99,7 @@
         </section>
 
         <!-- PAPERS -->
-        <section class="view hidden flex-fill-col" id="view_papers">
+        <section class="view hidden u-flex-fill-col" id="view_papers">
           <div class="toolbar">
             <input id="search" class="input" placeholder="Buscar por título, autor, tag…" />
             <select id="f_status" class="select">
@@ -159,7 +159,7 @@
         </section>
 
         <!-- ITERATIONS -->
-        <section class="view hidden flex-fill-col" id="view_iterations">
+        <section class="view hidden u-flex-fill-col" id="view_iterations">
           <div class="card">
             <div class="cardTitle">Iterações</div>
             <div class="row">
@@ -183,7 +183,7 @@
         </section>
 
         <!-- CRITERIA -->
-        <section class="view hidden flex-fill-col" id="view_criteria">
+        <section class="view hidden u-flex-fill-col" id="view_criteria">
           <div class="grid2">
             <div class="card">
               <div class="cardTitle">Cadastrar critérios</div>
@@ -212,7 +212,7 @@
         </section>
 
         <!-- CITATIONS -->
-        <section class="view hidden flex-fill-col" id="view_citations">
+        <section class="view hidden u-flex-fill-col" id="view_citations">
           <div class="card">
             <div class="cardTitle">Criar conexão (manual)</div>
             <div class="row">
@@ -234,7 +234,7 @@
         </section>
 
         <!-- GRAPH -->
-        <section class="view hidden flex-fill-col" id="view_graph">
+        <section class="view hidden u-flex-fill-col" id="view_graph">
           <div class="grid2">
             <div class="card">
               <div class="cardTitle">Grafo de citações (simples, offline)</div>
@@ -260,7 +260,7 @@
         </section>
 
         <!-- INSIGHTS -->
-        <section class="view hidden flex-fill-col" id="view_insights">
+        <section class="view hidden u-flex-fill-col" id="view_insights">
           <div class="grid2">
             <div class="card">
               <div class="cardTitle">Resumo automático da revisão</div>
@@ -305,7 +305,7 @@
         </section>
 
         <!-- CATEGORIES (moved from options) -->
-        <section class="view hidden flex-fill-col" id="view_categories">
+        <section class="view hidden u-flex-fill-col" id="view_categories">
           <div class="panelHeader">
             <h2>Categorias</h2>
             <p>Crie cores para marcar artigos</p>
@@ -322,12 +322,12 @@
             </div>
           </div>
 
-          <div class="card flex-fill-col" style="margin-top:12px">
+          <div class="card u-flex-fill-col" style="margin-top:12px">
             <div class="cardTitle">Lista de categorias</div>
             <div class="muted" style="margin-bottom:8px">Clique em <b>Excluir</b> para remover uma categoria.</div>
 
-            <div class="tableWrap flex-fill-col" style="margin-top:8px">
-              <ul id="categoryList" class="categoryList flex-fill-col u-scroll-y"></ul>
+            <div class="tableWrap u-flex-fill-col" style="margin-top:8px">
+              <ul id="categoryList" class="categoryList u-flex-fill-col u-scroll-y"></ul>
             </div>
           </div>
         </section>


### PR DESCRIPTION
[Adicionei uma classe reutilizável de css para scroll] Introduce two utility classes (.flex-fill-col and .u-scroll-y) to centralize vertical flex behavior and internal scrolling (with cross-browser scrollbar styles). Remove many scattered display:flex/flex-flow/min-height/overflow declarations from sidebar, cards, views, tableWrap and categoryList in CSS and update HTML to apply the new utilities to the sidebar, nav, view sections, papers table/tbody, category list and related wrappers. This simplifies layout, prevents parent growth that breaks internal scrolling, and consolidates scrollbar styling.

Relacionado à issue: #