### PR TITLE
Probe WS server before connecting; UI/log tweaks

### DIFF
--- a/infrastructure/socketManager.mjs
+++ b/infrastructure/socketManager.mjs
@@ -73,13 +73,44 @@ class WebsocketManager {
     this.finalizeClose("🔌 Desconectado", "Desconectado");
   }
 
-  connect(url, port) {
+  buildProbeUrl(wsUrl) {
+    return wsUrl.replace(/^wss?:\/\//i, (m) => m.toLowerCase().startsWith("wss") ? "https://" : "http://");
+  }
+
+  async isServerAvailable(wsUrl, timeoutMs = 1500) {
+    const probeUrl = this.buildProbeUrl(wsUrl);
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      // Qualquer resposta HTTP — inclusive 426 Upgrade Required de servidor WS-only —
+      // confirma que a porta está ativa. Só cai em catch quando há falha de rede.
+      await fetch(probeUrl, { method: "HEAD", cache: "no-store", signal: ctrl.signal });
+      return true;
+    } catch {
+      return false; // ERR_CONNECTION_REFUSED, timeout, etc.
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async connect(url, port) {
     if (this.socket && this.socket.readyState === WebSocket.OPEN) {
       this.appendLog("Já está conectado.");
       return;
     }
 
     const fullUrl = this.buildWsUrl(url, port);
+
+    const up = await this.isServerAvailable(fullUrl);
+    if (!up) {
+      this.setStatus("Desconectado");
+      this.appendLog("Servidor indisponível em " + fullUrl + ". Tentando novamente em breve...");
+      setTimeout(() => this.tryAutoConnect(), this.autoConnectionTime);
+      this.autoConnectionTime *= 2;
+      if (this.autoConnectionTime > 60000) this.autoConnectionTime = 60000;
+      return;
+    }
+
     this.setStatus("Conectando...");
     this.appendLog("Conectando em " + fullUrl);
     this._closedFinalized = false;
@@ -87,7 +118,6 @@ class WebsocketManager {
     // Atualiza a URL global para o nosso supressor silenciar os erros no console
     this.currentConnectingUrl = fullUrl;
 
-    
     try {
       this.socket = new WebSocket(fullUrl);
     } catch (e) {

--- a/infrastructure/storage.mjs
+++ b/infrastructure/storage.mjs
@@ -305,7 +305,7 @@ class WebSocketStrategy {
       const timer = setTimeout(() => {
         if (!isResolved) {
           isResolved = true;
-          console.warn("Timeout aguardando WebSocket.");
+          console.log("Timeout aguardando WebSocket.");
           resolve(false); 
         }
       }, timeoutMs);

--- a/ui/projects/projects.js
+++ b/ui/projects/projects.js
@@ -53,13 +53,13 @@ document.addEventListener('DOMContentLoaded', () => {
   /**
    * Exibe mensagem de placeholder quando não há projetos
    */
-  function showPlaceholder() {
+  function showPlaceholder(connectionIssue = false) {
     if (!elements.projectList) return;
     
     elements.projectList.innerHTML = '';
     const li = document.createElement('li');
     li.style.opacity = '0.8';
-    li.innerHTML = '<div class="left"><div class="title">Nenhum projeto encontrado</div></div>';
+    li.innerHTML = `<div class="left"><div class="title">${connectionIssue ? 'Erro de conexão com o servidor. Verifique se o servidor está rodando.' : 'Nenhum projeto encontrado'}</div></div>`;
     elements.projectList.appendChild(li);
   }
 
@@ -216,7 +216,7 @@ document.addEventListener('DOMContentLoaded', () => {
         await storage.openProject(project.id);
         window.location.href = '../dashboard/dashboard.html';
       } catch (e) {
-        console.warn('openProject failed', e);
+        console.log('openProject failed', e);
         alert('Falha ao abrir o projeto. Veja console.');
       }
     });
@@ -242,7 +242,7 @@ document.addEventListener('DOMContentLoaded', () => {
       try { 
         await storage.archiveProject(project.id); 
       } catch (e) { 
-        console.warn('archiveProject failed', e); 
+        console.log('archiveProject failed', e); 
       }
       
       li.remove();
@@ -365,7 +365,7 @@ document.addEventListener('DOMContentLoaded', () => {
       closeSidenav();
       await loadProjectsFromStorage();
     } catch (e) {
-      console.warn('saveProject failed', e);
+      console.log('saveProject failed', e);
       alert('Falha ao salvar o projeto. Veja console.');
     }
   }
@@ -424,7 +424,8 @@ document.addEventListener('DOMContentLoaded', () => {
       projects = await storage.listProjects();
       renderProjects(elements.filterInput?.value || '');
     } catch (e) {
-      console.warn('Failed to load projects from storage', e);
+      showPlaceholder(true);
+      console.log('Failed to load projects from storage', e);
     }
   }
 
@@ -478,12 +479,6 @@ document.addEventListener('DOMContentLoaded', () => {
     // Carrega projetos
     await loadProjectsFromStorage();
     
-    // Placeholder de segurança (caso o carregamento falhe)
-    setTimeout(() => {
-      if (!projects.length && elements.projectList) {
-        showPlaceholder();
-      }
-    }, 6000);
   }
 
   // Inicia a aplicação


### PR DESCRIPTION
Resolve o problema de poluição (log de erro quando o servidor está fora) no gerenciador de extensões do chrome.

Add a server availability probe to WebsocketManager: buildProbeUrl converts ws:///wss:// to http(s) and isServerAvailable uses a HEAD fetch with timeout to detect service availability. connect() now checks availability, logs and schedules exponential backoff when the server is down before attempting a WebSocket connection. Minor cleanups: adjust a stray whitespace. Change storage timeout warning from console.warn to console.log. In projects UI, make the placeholder show a connection error message when appropriate, replace several console.warn calls with console.log, show the placeholder on load failure, and remove an unnecessary fallback placeholder timeout.

Relacionado à issue: #